### PR TITLE
Fixes broken TLC Resource link on English and French page

### DIFF
--- a/notes-en.html
+++ b/notes-en.html
@@ -46,7 +46,7 @@
 
         * Scratch <a href="https://scratch.mit.edu/educators/#resources">Educator Resources</a> (especially the <a href="https://cdn.scratch.mit.edu/scratchr2/static/__0c1805349a6fe15c01c668d3f8acd971__/pdfs/help/Getting-Started-Guide-Scratch2.pdf">Getting Started Guide</a>)
         * Google CS First <a href="https://www.cs-first.com/training/introduction-computer-science-and-scratch">Training Materials</a>
-        * Teachers Learning Code <a href="http://teacherslearningcode.com/assets/TLC-gettingstartedguide.pdf">Guide</a>
+        * Teachers Learning Code <a href="https://www.canadalearningcode.ca/wp-content/uploads/teacher-quick-start-guide.pdf">Guide</a>
         * Scratch ED: Using the Scratch <a href="http://scratched.gse.harvard.edu/resources/scratch-teacher-accounts">Teacher Account</a>
 
         <br>
@@ -135,7 +135,7 @@
 
         * Scratch <a href="https://scratch.mit.edu/educators/#resources">Educator Resources</a> (especially the <a href="https://cdn.scratch.mit.edu/scratchr2/static/__0c1805349a6fe15c01c668d3f8acd971__/pdfs/help/Getting-Started-Guide-Scratch2.pdf">Getting Started Guide</a>)
         * Google CS First <a href="https://www.cs-first.com/training/introduction-computer-science-and-scratch">Training Materials</a>
-        * Teachers Learning Code <a href="http://teacherslearningcode.com/assets/TLC-gettingstartedguide.pdf">Guide</a>
+        * Teachers Learning Code <a href="https://www.canadalearningcode.ca/wp-content/uploads/teacher-quick-start-guide.pdf">Guide</a>
         * Scratch ED: Using the Scratch <a href="http://scratched.gse.harvard.edu/resources/scratch-teacher-accounts">Teacher Account</a>
 
       </script>

--- a/notes-fr.html
+++ b/notes-fr.html
@@ -134,7 +134,7 @@
 
         * <a href="https://scratch.mit.edu/educators/#resources">Ressources de Scratch pour les enseignants</a> (particulièrement le <a href="https://cdn.scratch.mit.edu/scratchr2/static/__0c1805349a6fe15c01c668d3f8acd971__/pdfs/help/Getting-Started-Guide-Scratch2.pdf">guide de démarrage</a>, en anglais)
         * <a href="https://www.cs-first.com/training/introduction-computer-science-and-scratch">Formation de Google CS First</a>
-        * <a href="http://teacherslearningcode.com/assets/TLC-gettingstartedguide.pdf">Guide de Teachers Learning Code</a>
+        * <a href="https://www.canadalearningcode.ca/wp-content/uploads/teacher-quick-start-guide.pdf">Guide de Teachers Learning Code</a>
         *  <a href="http://scratched.gse.harvard.edu/resources/scratch-teacher-accounts">Scratch ED: Using the Scratch Teacher Account (guide pour les comptes pour enseignant, en anglais)</a>
 
       </script>

--- a/notes-fr.html
+++ b/notes-fr.html
@@ -46,7 +46,7 @@
 
         * <a href="https://scratch.mit.edu/educators/#resources">Ressources de Scratch pour les enseignants</a> (particulièrement le <a href="https://cdn.scratch.mit.edu/scratchr2/static/__0c1805349a6fe15c01c668d3f8acd971__/pdfs/help/Getting-Started-Guide-Scratch2.pdf">guide de démarrage</a>, en anglais)
         * <a href="https://www.cs-first.com/training/introduction-computer-science-and-scratch">Formation de Google CS First</a>
-        * <a href="http://teacherslearningcode.com/assets/TLC-gettingstartedguide.pdf">Guide de Teachers Learning Code</a>
+        * <a href="https://www.canadalearningcode.ca/wp-content/uploads/teacher-quick-start-guide.pdf">Guide de Teachers Learning Code</a>
         *  <a href="http://scratched.gse.harvard.edu/resources/scratch-teacher-accounts">Scratch ED: Using the Scratch Teacher Account (guide pour les comptes pour enseignant, en anglais)</a>
 
         <br>


### PR DESCRIPTION
Old version also linked to English copy of the TLC "Getting Started Guide" - it appears there is no french translation of that document.